### PR TITLE
chore: use isServer instead of typeof window === "undefined"

### DIFF
--- a/src/use-window-size.ts
+++ b/src/use-window-size.ts
@@ -2,35 +2,35 @@ import { $, useOnWindow, useSignal, useTask$ } from "@builder.io/qwik";
 import { isServer } from "@builder.io/qwik/build";
 
 type WindowSize = {
-  width: number;
-  height: number;
+    width: number;
+    height: number;
 };
 
 const useWindowSize = () => {
-  const size = useSignal<WindowSize>();
+    const size = useSignal<WindowSize>();
 
-  const handleResize = $(() => {
-    size.value = {
-      width: window.innerWidth,
-      height: window.innerHeight,
-    };
-  });
+    const handleResize = $(() => {
+        size.value = {
+            width: window.innerWidth,
+            height: window.innerHeight,
+        };
+    });
 
-  /**
-   * useTask$ triggers when the hooks is called after client-side routing.
-   * useOnWindow("load") triggers when the page is loaded server-side.
-   * useOnWindow("resize") triggers when the page is resized.
-   */
+    /**
+     * useTask$ triggers when the hooks is called after client-side routing.
+     * useOnWindow("load") triggers when the page is loaded server-side.
+     * useOnWindow("resize") triggers when the page is resized.
+     */
 
-  useTask$(() => {
-    if (isServer) return;
-    handleResize();
-  });
+    useTask$(() => {
+        if (isServer) return;
+        handleResize();
+    });
 
-  useOnWindow("load", handleResize);
-  useOnWindow("resize", handleResize);
+    useOnWindow("load", handleResize);
+    useOnWindow("resize", handleResize);
 
-  return size;
+    return size;
 };
 
 export { useWindowSize };

--- a/src/use-window-size.ts
+++ b/src/use-window-size.ts
@@ -1,35 +1,36 @@
 import { $, useOnWindow, useSignal, useTask$ } from "@builder.io/qwik";
+import { isServer } from "@builder.io/qwik/build";
 
 type WindowSize = {
-    width: number;
-    height: number;
+  width: number;
+  height: number;
 };
 
 const useWindowSize = () => {
-    const size = useSignal<WindowSize>();
+  const size = useSignal<WindowSize>();
 
-    const handleResize = $(() => {
-        size.value = {
-            width: window.innerWidth,
-            height: window.innerHeight,
-        };
-    });
+  const handleResize = $(() => {
+    size.value = {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    };
+  });
 
-    /**
-     * useTask$ triggers when the hooks is called after client-side routing.
-     * useOnWindow("load") triggers when the page is loaded server-side.
-     * useOnWindow("resize") triggers when the page is resized.
-     */
+  /**
+   * useTask$ triggers when the hooks is called after client-side routing.
+   * useOnWindow("load") triggers when the page is loaded server-side.
+   * useOnWindow("resize") triggers when the page is resized.
+   */
 
-    useTask$(() => {
-        if (typeof window === "undefined") return;
-        handleResize();
-    });
+  useTask$(() => {
+    if (isServer) return;
+    handleResize();
+  });
 
-    useOnWindow("load", handleResize);
-    useOnWindow("resize", handleResize);
+  useOnWindow("load", handleResize);
+  useOnWindow("resize", handleResize);
 
-    return size;
+  return size;
 };
 
 export { useWindowSize };


### PR DESCRIPTION
isServer is more robust than typeof window === "undefined".

Here's the source code:
```tsx
/**
 * True when build is made for browser, client-side execution.
 *
 * @public
 */
export const isBrowser: boolean = /*#__PURE__*/ (() =>
  typeof window !== 'undefined' &&
  typeof HTMLElement !== 'undefined' &&
  !!window.document &&
  String(HTMLElement).includes('[native code]'))();

/**
 * True when build is made for SSR purposes.
 *
 * @public
 */
export const isServer: boolean = !isBrowser;
```