### PR TITLE
fix: 🐛 hook doc page by changing shiki to 100% client-side

### DIFF
--- a/website/src/components/code-preview/code-preview.tsx
+++ b/website/src/components/code-preview/code-preview.tsx
@@ -1,4 +1,10 @@
-import { type ClassList, type PropsOf, component$, useSignal, useTask$ } from "@builder.io/qwik";
+import {
+    type ClassList,
+    type PropsOf,
+    component$,
+    useSignal,
+    useVisibleTask$,
+} from "@builder.io/qwik";
 import { cn } from "@qwik-ui/utils";
 import { CodeCopy } from "./code-copy";
 import { highlighter as highlighterPromise } from "./highlighter";
@@ -21,7 +27,7 @@ export default component$(
         ...props
     }: CodePreviewProps) => {
         const codeSig = useSignal("");
-        useTask$(async function createHighlightedCode() {
+        useVisibleTask$(async function createHighlightedCode() {
             const highlighter = await highlighterPromise;
             let modifiedCode: string = code;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the task visibility function within the code preview component for improved clarity and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->