### PR TITLE
docs: ✏️ add useClickOutsideDocs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { useLocalStorage } from "./use-local-storage";
 export { usePrevious } from "./use-previous";
 export { useMediaQuery } from "./use-media-query";
 export { useOrientation } from "./use-orientation";
+export { useClickOutside } from "./use-click-outside";

--- a/website/src/components/hooks/hook-return.tsx
+++ b/website/src/components/hooks/hook-return.tsx
@@ -7,6 +7,11 @@ type HookReturnProps = {
 };
 
 export default component$<HookReturnProps>((props) => {
+
+    if (!props.return) {
+        return null;
+    }
+
     return (
         <div id="hook-return" class="flex flex-col gap-8">
             <span class="font-bold text-secondary text-base md:text-xl lg:text-xl">

--- a/website/src/docs/click-outside/code.ts
+++ b/website/src/docs/click-outside/code.ts
@@ -1,0 +1,32 @@
+export default `
+import { $, component$, useSignal } from "@builder.io/qwik";
+import { Button } from "~/components/ui/button/button";
+import { useClickOutside } from "@ditadi/qwik-hooks";
+
+export default component$(() => {
+    const isDialogOpen = useSignal(false);
+    const ref = useSignal<HTMLDivElement>();
+
+    useClickOutside(
+        ref,
+        $(() => {
+            isDialogOpen.value = false;
+        }),
+    );
+
+    return (
+        <div class="flex flex-col bg-background w-full items-center p-10 gap-5">
+            <Button
+                onClick$={async () => {
+                    isDialogOpen.value = true;
+                }}
+            >
+                Open Dialog
+            </Button>
+            <dialog ref={ref} class="bg-white p-5 rounded-lg" open={isDialogOpen.value}>
+                <span class="text-lg">Click outside this dialog</span>
+            </dialog>
+        </div>
+    );
+});
+`;

--- a/website/src/docs/click-outside/demo.tsx
+++ b/website/src/docs/click-outside/demo.tsx
@@ -1,0 +1,30 @@
+import { $, component$, useSignal } from "@builder.io/qwik";
+import { Button } from "~/components/ui/button/button";
+import { useClickOutside } from "../../../../src";
+
+export default component$(() => {
+    const isDialogOpen = useSignal(false);
+    const ref = useSignal<HTMLDivElement>();
+
+    useClickOutside(
+        ref,
+        $(() => {
+            isDialogOpen.value = false;
+        }),
+    );
+
+    return (
+        <div class="flex flex-col bg-background w-full items-center p-10 gap-5">
+            <Button
+                onClick$={async () => {
+                    isDialogOpen.value = true;
+                }}
+            >
+                Open Dialog
+            </Button>
+            <dialog ref={ref} class="bg-white p-5 rounded-lg" open={isDialogOpen.value}>
+                <span class="text-lg">Click outside this dialog</span>
+            </dialog>
+        </div>
+    );
+});

--- a/website/src/docs/click-outside/doc.tsx
+++ b/website/src/docs/click-outside/doc.tsx
@@ -1,0 +1,21 @@
+import type { HookDoc } from "..";
+import UseClickOutsideCode from "./code";
+import UseClickOutsideDemo from "./demo";
+
+export default {
+    key: "useclickoutside",
+    title: "useClickOutside",
+    highlight: "Detect clicks outside of specific component with useClickOutside.",
+    description:
+        "The useClickOutside hook is a useful for detecting clicks outside a specific component. It allows you to pass a callback function that will be triggered whenever a click occurs outside the component’s area. This hook is particularly helpful when implementing dropdown menus, modals, or any other UI elements that need to be closed when the user clicks outside of them. By attaching event listeners to the document, the hook checks if the click target is within the component’s reference, and if not, it invokes the provided callback function.",
+    params: [
+        {
+            name: "callback",
+            type: "function",
+            description:
+                "The callback function that is provided as an argument to useClickOutside. This function is invoked whenever a click event is detected outside of the referenced element. The event object from the click is passed to this callback function.",
+        },
+    ],
+    demo: UseClickOutsideDemo,
+    code: UseClickOutsideCode,
+} as HookDoc;

--- a/website/src/docs/index.ts
+++ b/website/src/docs/index.ts
@@ -4,6 +4,7 @@ import useLocalStorage from "./local-storage/doc";
 import useMediaQuery from "./media-query/doc";
 import usePrevious from "./previous/doc";
 import useWindowSize from "./window-size/doc";
+import useClickOutside from "./click-outside/doc";
 
 export interface HookParams {
     name: string;
@@ -35,4 +36,5 @@ export default [
     useWindowSize,
     usePrevious,
     useMediaQuery,
+    useClickOutside,
 ] as HookDoc[];

--- a/website/src/docs/local-storage/code.ts
+++ b/website/src/docs/local-storage/code.ts
@@ -1,5 +1,4 @@
 export default `
-s
 import { component$ } from "@builder.io/qwik";
 import { useLocalStorage } from "@ditadi/qwik-hooks";
 import { Button } from "~/components/ui/button/button";


### PR DESCRIPTION
add simple dialog test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `useClickOutside` hook for handling clicks outside a designated component, useful for closing modals or dropdowns.
	- Added a demo component showcasing the functionality of opening and closing a dialog box by clicking outside of it.

- **Bug Fixes**
	- Corrected a typo in the export statement of the local storage documentation.

- **Documentation**
	- Updated documentation to include the new `useClickOutside` hook and its application in web components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->