### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ A collection of modern qwik hooks – from the [@ditadi](https://twitter.com/vic
 
 ### Hooks
 
-- [useDebounce](https://qwikhooks.dev/usedebounce)
-- [useLocalStorage](https://qwikhooks.dev/uselocalstorage)
-- [useCopyClipboard](https://qwikhooks.dev/usecopytoclipboard)
-- [useWindowSize](https://qwikhooks.dev/usewindowsize)
-- [usePrevious](https://qwikhooks.dev/useprevious)
-- [useMediaQuery](https://qwikhooks.dev/usemediaquery)
-- [useOrientation](https://qwikhooks.dev/useOrientation)
-- [useClickOutside](https://qwikhooks.dev/useClickOutside)
+- [useDebounce](https://www.qwikhooks.dev/usedebounce/)
+- [useLocalStorage](https://www.qwikhooks.dev/uselocalstorage/)
+- [useCopyClipboard](https://www.qwikhooks.dev/usecopytoclipboard/)
+- [useWindowSize](https://www.qwikhooks.dev/usewindowsize/)
+- [usePrevious](https://www.qwikhooks.dev/useprevious/)
+- [useMediaQuery](https://www.qwikhooks.dev/usemediaquery/)
+- [useOrientation](https://www.qwikhooks.dev/useorientation/)
+- [useClickOutside](https://qwikhooks.dev/useclickoutside/)
 
 
 ## License


### PR DESCRIPTION
Fixed incorrect URL to https://www.qwikhooks.dev/useclickoutside/

Fixed Redirect -> "/"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated URLs in the documentation to include `www` in the domain for better accessibility and standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->